### PR TITLE
Use ConcurrentQueue instead of lock() and Semaphore

### DIFF
--- a/MultiPongServer/Program.cs
+++ b/MultiPongServer/Program.cs
@@ -46,7 +46,6 @@ namespace MultiPongServer
 
             while (true)
             {
-                while(!networkClient.CanReceive);
                 var message = networkClient.Receive();
                 Handle(message);
                 current = stopwatch.Elapsed;

--- a/MultiPongServer/Program.cs
+++ b/MultiPongServer/Program.cs
@@ -46,6 +46,7 @@ namespace MultiPongServer
 
             while (true)
             {
+                while(!networkClient.CanReceive);
                 var message = networkClient.Receive();
                 Handle(message);
                 current = stopwatch.Elapsed;
@@ -57,6 +58,7 @@ namespace MultiPongServer
 
         private void Handle(Message message)
         {
+            if(message == null)return;
             Message messageToSend;
             switch (message.MessageType)
             {


### PR DESCRIPTION
Now Receive() may return null if no message has arrived. If you want to wait for a message use ReceiveBlocking()

In PongGame movePad() will only send after receiving an update message. Otherwise it overflows the Server's queue

@adbak it needs testing on Windows :)